### PR TITLE
Use int64 for filesize

### DIFF
--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -253,9 +253,8 @@ func bail(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func formatBytes(b int) string {
-	const unit = 1000
 func formatBytes(b int64) string {
+	const unit = 1000
 	if b < unit {
 		return fmt.Sprintf("%d B", b)
 	}

--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -255,6 +255,7 @@ func bail(msg string, args ...interface{}) {
 
 func formatBytes(b int) string {
 	const unit = 1000
+func formatBytes(b int64) string {
 	if b < unit {
 		return fmt.Sprintf("%d B", b)
 	}
@@ -276,11 +277,11 @@ func (p *proxyReadCloser) Close() error {
 	return nil
 }
 
-func pbProxyReader(r io.Reader, size int) io.ReadCloser {
+func pbProxyReader(r io.Reader, size int64) io.ReadCloser {
 	if hideProgressBar {
 		return ioutil.NopCloser(r)
 	} else {
-		progressBar := pb.Full.Start(size)
+		progressBar := pb.Full.Start64(size)
 		proxyReader := progressBar.NewProxyReader(r)
 		return &proxyReadCloser{
 			Reader: proxyReader,

--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -83,7 +83,7 @@ func recvAction(cmd *cobra.Command, args []string) {
 			errf("Error stat'ing existing '%s'\n", msg.Name)
 		} else {
 			reader := bufio.NewReader(os.Stdin)
-			fmt.Printf("Receiving file (%s) into: %s\n", formatBytes(msg.TransferBytes), msg.Name)
+			fmt.Printf("Receiving file (%s) into: %s\n", formatBytes(msg.TransferBytes64), msg.Name)
 			fmt.Print("ok? (y/N):")
 
 			line, err := reader.ReadString('\n')
@@ -108,7 +108,7 @@ func recvAction(cmd *cobra.Command, args []string) {
 					bail("Failed to create tempfile: %s", err)
 				}
 
-				proxyReader := pbProxyReader(msg, msg.TransferBytes)
+				proxyReader := pbProxyReader(msg, msg.TransferBytes64)
 
 				_, err = io.Copy(f, proxyReader)
 				if err != nil {
@@ -151,8 +151,8 @@ func recvAction(cmd *cobra.Command, args []string) {
 			errf("Error stat'ing existing '%s'\n", msg.Name)
 		} else {
 			reader := bufio.NewReader(os.Stdin)
-			fmt.Printf("Receiving directory (%s) into: %s\n", formatBytes(msg.TransferBytes), msg.Name)
-			fmt.Printf("%d files, %s (uncompressed)\n", msg.FileCount, formatBytes(msg.UncompressedBytes))
+			fmt.Printf("Receiving directory (%s) into: %s\n", formatBytes(msg.TransferBytes64), msg.Name)
+			fmt.Printf("%d files, %s (uncompressed)\n", msg.FileCount, formatBytes(msg.UncompressedBytes64))
 			fmt.Print("ok? (y/N):")
 
 			line, err := reader.ReadString('\n')
@@ -181,7 +181,7 @@ func recvAction(cmd *cobra.Command, args []string) {
 				defer tmpFile.Close()
 				defer os.Remove(tmpFile.Name())
 
-				proxyReader := pbProxyReader(msg, msg.TransferBytes)
+				proxyReader := pbProxyReader(msg, msg.TransferBytes64)
 
 				n, err := io.Copy(tmpFile, proxyReader)
 				if err != nil {

--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -126,14 +126,14 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 	} else if offer.File != nil {
 		fr.Type = TransferFile
 		fr.Name = offer.File.FileName
-		fr.TransferBytes = int(offer.File.FileSize)
-		fr.UncompressedBytes = int(offer.File.FileSize)
+		fr.TransferBytes = offer.File.FileSize
+		fr.UncompressedBytes = offer.File.FileSize
 		fr.FileCount = 1
 	} else if offer.Directory != nil {
 		fr.Type = TransferDirectory
 		fr.Name = offer.Directory.Dirname
-		fr.TransferBytes = int(offer.Directory.ZipSize)
-		fr.UncompressedBytes = int(offer.Directory.NumBytes)
+		fr.TransferBytes = offer.Directory.ZipSize
+		fr.UncompressedBytes = offer.Directory.NumBytes
 		fr.FileCount = int(offer.Directory.NumFiles)
 	} else {
 		return nil, errors.New("Got non-file transfer offer")
@@ -247,8 +247,8 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 type IncomingMessage struct {
 	Name              string
 	Type              TransferType
-	TransferBytes     int
-	UncompressedBytes int
+	TransferBytes     int64
+	UncompressedBytes int64
 	FileCount         int
 
 	textReader io.Reader
@@ -259,7 +259,7 @@ type IncomingMessage struct {
 
 	cryptor   *transportCryptor
 	buf       []byte
-	readCount int
+	readCount int64
 	sha256    hash.Hash
 
 	readErr error
@@ -337,7 +337,7 @@ func (f *IncomingMessage) readCrypt(p []byte) (int, error) {
 
 	n := copy(p, f.buf)
 	f.buf = f.buf[n:]
-	f.readCount += n
+	f.readCount += int64(n)
 	f.sha256.Write(p[:n])
 	if f.readCount >= f.TransferBytes {
 		f.readErr = io.EOF

--- a/wormhole/wormhole_test.go
+++ b/wormhole/wormhole_test.go
@@ -285,8 +285,8 @@ func TestWormholeBigFileTransportSendRecvViaRelayServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if int64(receiver.TransferBytes) != fakeBigSize {
-		t.Fatalf("Mismatch in size between what we are trying to send and what is (our parsed) offer. Expected %v but got %v", fakeBigSize, receiver.TransferBytes)
+	if int64(receiver.TransferBytes64) != fakeBigSize {
+		t.Fatalf("Mismatch in size between what we are trying to send and what is (our parsed) offer. Expected %v but got %v", fakeBigSize, receiver.TransferBytes64)
 	}
 
 }


### PR DESCRIPTION
This is a quick attempt at making wormhole-william support files bigger than 2 GiB on 32 bit architectures. 

I ran in to this limitation when trying to transfer a big file to a 32 bit host. The receiver only saw the file as ~2GIB and only downloaded the first 2GiB. These are the fixes I did to make it work.

I also created a simple test which sets things up to transfer a ~30 GiB file, this test fails on `GOARCH=386` without the int64 fix.

My Golang is really rusty, so I'd appreciate any feedback :-)