### PR TITLE
Cross compile/run tests against i386

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,11 +8,9 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        go-version: [1.13.9, 1.14.1]
-
+        go-version: [1.13.11, 1.14.3]
 
     steps:
-
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
@@ -27,6 +25,9 @@ jobs:
 
     - name: Test
       run: go test -v ./... --timeout 60s
+
+    - name: Cross test for i386
+      run: env GOOS=linux GOARCH=386 go test -v ./... --timeout 60s
 
     - name: Cross compile for arm (RPI)
       run: env GOOS=linux GOARCH=arm GOARM=5 go build -v ./...


### PR DESCRIPTION
This is to try to catch issues like #13 (and for the test case
added in that pr to have a failing target).