### PR TITLE
Small code fixes throughout the codebase

### DIFF
--- a/rendezvous/rendezvousservertest/rendezvousservertest.go
+++ b/rendezvous/rendezvousservertest/rendezvousservertest.go
@@ -146,7 +146,7 @@ func serverUnmarshal(m []byte) (interface{}, error) {
 
 	protoType, found := msgs.MsgMap[genericMsg.Type]
 	if !found {
-		return nil, fmt.Errorf("Unknown msg type: %s %v %s\n", genericMsg.Type, genericMsg, m)
+		return nil, fmt.Errorf("unknown msg type: %s %v %s", genericMsg.Type, genericMsg, m)
 	}
 	t := reflect.TypeOf(protoType)
 	val := reflect.New(t)
@@ -267,7 +267,7 @@ func (ts *TestServer) handleWS(w http.ResponseWriter, r *http.Request) {
 			ts.mu.Unlock()
 
 			if nameplate < 1 {
-				errMsg(m.ID, m, fmt.Errorf("Failed to allocate nameplate"))
+				errMsg(m.ID, m, fmt.Errorf("failed to allocate nameplate"))
 				continue
 			}
 
@@ -287,7 +287,7 @@ func (ts *TestServer) handleWS(w http.ResponseWriter, r *http.Request) {
 			mboxID := ts.nameplates[int16(nameplate)]
 			ts.mu.Unlock()
 			if mboxID == "" {
-				errMsg(m.ID, m, fmt.Errorf("No namespaces available"))
+				errMsg(m.ID, m, fmt.Errorf("no namespaces available"))
 				continue
 			}
 
@@ -295,7 +295,7 @@ func (ts *TestServer) handleWS(w http.ResponseWriter, r *http.Request) {
 			mbox := ts.mailboxes[mboxID]
 			ts.mu.Unlock()
 			if mbox == nil {
-				errMsg(m.ID, m, fmt.Errorf("No mailbox found associated to nameplate %s", m.Nameplate))
+				errMsg(m.ID, m, fmt.Errorf("no mailbox found associated to nameplate %s", m.Nameplate))
 				continue
 			}
 
@@ -330,7 +330,7 @@ func (ts *TestServer) handleWS(w http.ResponseWriter, r *http.Request) {
 			ts.mu.Unlock()
 
 			if mbox == nil {
-				errMsg(m.ID, m, errors.New("Mailbox not found"))
+				errMsg(m.ID, m, errors.New("mailbox not found"))
 				continue
 			}
 
@@ -368,7 +368,7 @@ func (ts *TestServer) handleWS(w http.ResponseWriter, r *http.Request) {
 
 			nameplate, err := strconv.Atoi(m.Nameplate)
 			if err != nil {
-				errMsg(m.ID, m, errors.New("No nameplate found"))
+				errMsg(m.ID, m, errors.New("no nameplate found"))
 				continue
 			}
 

--- a/wormhole/file_transport.go
+++ b/wormhole/file_transport.go
@@ -101,7 +101,7 @@ func (d *transportCryptor) readRecord() ([]byte, error) {
 	bigNonce.SetBytes(nonce[:])
 
 	if bigNonce.Cmp(d.nextReadNonce) != 0 {
-		d.err = errors.New("Received out-of-order record")
+		d.err = errors.New("received out-of-order record")
 		return nil, d.err
 	}
 
@@ -356,7 +356,7 @@ func (t *fileTransport) makeTransitMsg() (*transitMsg, error) {
 
 		port, err := strconv.Atoi(portStr)
 		if err != nil {
-			return nil, fmt.Errorf("Port isn't an integer? %s", portStr)
+			return nil, fmt.Errorf("port isn't an integer? %s", portStr)
 		}
 
 		addrs := nonLocalhostAddresses()
@@ -379,7 +379,7 @@ func (t *fileTransport) makeTransitMsg() (*transitMsg, error) {
 
 		relayPort, err := strconv.Atoi(portStr)
 		if err != nil {
-			return nil, fmt.Errorf("Port isn't an integer? %s", portStr)
+			return nil, fmt.Errorf("port isn't an integer? %s", portStr)
 		}
 
 		msg.HintsV1 = append(msg.HintsV1, transitHintsV1{
@@ -499,7 +499,7 @@ func (t *fileTransport) waitForRelayPeer(conn net.Conn, cancelCh chan struct{}) 
 
 	if !bytes.Equal(gotOk, []byte("ok\n")) {
 		conn.Close()
-		return errors.New("Got non ok status from relay server")
+		return errors.New("got non ok status from relay server")
 	}
 
 	return nil
@@ -603,15 +603,6 @@ func (t *fileTransport) handleIncomingConnection(conn net.Conn, readyCh chan<- n
 		conn.Close()
 	case readyCh <- conn:
 	}
-}
-
-func (t *fileTransport) close() error {
-	if t.listener != nil {
-		err := t.listener.Close()
-		t.listener = nil
-		return err
-	}
-	return nil
 }
 
 func nonLocalhostAddresses() []string {

--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -41,7 +41,7 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 	if err != nil {
 		return nil, err
 	}
-	nameplate, err := nameplaceFromCode(code)
+	nameplate, err := nameplateFromCode(code)
 	if err != nil {
 		return nil, err
 	}

--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -136,7 +136,7 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 		fr.UncompressedBytes = int(offer.Directory.NumBytes)
 		fr.FileCount = int(offer.Directory.NumFiles)
 	} else {
-		return nil, errors.New("Got non-file transfer offer")
+		return nil, errors.New("got non-file transfer offer")
 	}
 
 	var gotTransitMsg transitMsg
@@ -150,7 +150,7 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 
 	transitMsg, err := transport.makeTransitMsg()
 	if err != nil {
-		return nil, fmt.Errorf("Make transit msg error: %s", err)
+		return nil, fmt.Errorf("make transit msg error: %s", err)
 	}
 
 	err = clientProto.WriteAppData(ctx, &genericMessage{
@@ -223,7 +223,7 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 		}
 
 		if conn == nil {
-			return errors.New("Failed to establish connection")
+			return errors.New("failed to establish connection")
 		}
 
 		cryptor := newTransportCryptor(conn, transitKey, "transit_record_sender_key", "transit_record_receiver_key")
@@ -277,7 +277,7 @@ func (f *IncomingMessage) Read(p []byte) (int, error) {
 	case TransferFile, TransferDirectory:
 		return f.readCrypt(p)
 	default:
-		return 0, fmt.Errorf("Unknown Receiver type %d", f.Type)
+		return 0, fmt.Errorf("unknown Receiver type %d", f.Type)
 	}
 }
 
@@ -292,7 +292,7 @@ func (f *IncomingMessage) Reject() error {
 	switch f.Type {
 	case TransferFile, TransferDirectory:
 	default:
-		return errors.New("Can only reject File and Directory transfers")
+		return errors.New("can only reject File and Directory transfers")
 	}
 
 	if f.readErr != nil {
@@ -300,7 +300,7 @@ func (f *IncomingMessage) Reject() error {
 	}
 
 	if f.transferInitialized {
-		return errors.New("Cannot Reject after calls to Read")
+		return errors.New("cannot Reject after calls to Read")
 	}
 
 	f.transferInitialized = true

--- a/wormhole/send.go
+++ b/wormhole/send.go
@@ -54,7 +54,7 @@ func (c *Client) SendText(ctx context.Context, msg string, opts ...SendOption) (
 		pwStr = nameplate + "-" + wordlist.ChooseWords(c.wordCount())
 	} else {
 		pwStr = options.code
-		nameplate, err := nameplaceFromCode(pwStr)
+		nameplate, err := nameplateFromCode(pwStr)
 		if err != nil {
 			return "", nil, err
 		}
@@ -208,7 +208,7 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 		pwStr = nameplate + "-" + wordlist.ChooseWords(c.wordCount())
 	} else {
 		pwStr = options.code
-		nameplate, err := nameplaceFromCode(pwStr)
+		nameplate, err := nameplateFromCode(pwStr)
 		if err != nil {
 			return "", nil, err
 		}
@@ -630,7 +630,7 @@ func validateCode(code string) error {
 	if code == "" {
 		return nil
 	}
-	_, err := nameplaceFromCode(code)
+	_, err := nameplateFromCode(code)
 	if err != nil {
 		return err
 	}

--- a/wormhole/send.go
+++ b/wormhole/send.go
@@ -87,7 +87,6 @@ func (c *Client) SendText(ctx context.Context, msg string, opts ...SendOption) (
 			}
 			returnErr = err
 			close(ch)
-			return
 		}
 
 		err = clientProto.WritePake(ctx, pwStr)
@@ -168,7 +167,7 @@ func (c *Client) SendText(ctx context.Context, msg string, opts ...SendOption) (
 			close(ch)
 			return
 		} else {
-			sendErr(fmt.Errorf("Unexpected answer"))
+			sendErr(fmt.Errorf("unexpected answer"))
 			return
 		}
 	}()
@@ -178,7 +177,7 @@ func (c *Client) SendText(ctx context.Context, msg string, opts ...SendOption) (
 
 func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Reader, opts ...SendOption) (string, chan SendResult, error) {
 	if err := c.validateRelayAddr(); err != nil {
-		return "", nil, fmt.Errorf("Invalid TransitRelayAddress: %s", err)
+		return "", nil, fmt.Errorf("invalid TransitRelayAddress: %s", err)
 	}
 
 	var options sendOptions
@@ -241,7 +240,6 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 			}
 			returnErr = err
 			close(ch)
-			return
 		}
 
 		err = clientProto.WritePake(ctx, pwStr)
@@ -305,7 +303,7 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 
 		transit, err := transport.makeTransitMsg()
 		if err != nil {
-			sendErr(fmt.Errorf("Make transit msg error: %s", err))
+			sendErr(fmt.Errorf("make transit msg error: %s", err))
 			return
 		}
 
@@ -341,7 +339,7 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 		}
 
 		if answer.FileAck != "ok" {
-			sendErr(fmt.Errorf("Unexpected answer"))
+			sendErr(fmt.Errorf("unexpected answer"))
 			return
 		}
 
@@ -402,13 +400,13 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 		}
 
 		if ack.Ack != "ok" {
-			sendErr(errors.New("Got non ok final ack from receiver"))
+			sendErr(errors.New("got non ok final ack from receiver"))
 			return
 		}
 
 		shaSum := fmt.Sprintf("%x", hasher.Sum(nil))
 		if strings.ToLower(ack.SHA256) != shaSum {
-			sendErr(fmt.Errorf("Receiver sha256 mismatch %s vs %s", ack.SHA256, shaSum))
+			sendErr(fmt.Errorf("receiver sha256 mismatch %s vs %s", ack.SHA256, shaSum))
 			return
 		}
 
@@ -416,7 +414,6 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 			OK: true,
 		}
 		close(ch)
-		return
 	}()
 
 	return pwStr, ch, nil
@@ -427,7 +424,7 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 // and an error if one occurred.
 func (c *Client) SendFile(ctx context.Context, fileName string, r io.ReadSeeker, opts ...SendOption) (string, chan SendResult, error) {
 	if err := c.validateRelayAddr(); err != nil {
-		return "", nil, fmt.Errorf("Invalid TransitRelayAddress: %s", err)
+		return "", nil, fmt.Errorf("invalid TransitRelayAddress: %s", err)
 	}
 
 	size, err := readSeekerSize(r)
@@ -509,7 +506,7 @@ func makeTmpZip(directoryName string, entries []DirectoryEntry) (*zipResult, err
 	}
 
 	if len(entries) < 1 {
-		return nil, errors.New("No files provided")
+		return nil, errors.New("no files provided")
 	}
 
 	defer os.Remove(f.Name())
@@ -529,7 +526,7 @@ func makeTmpZip(directoryName string, entries []DirectoryEntry) (*zipResult, err
 
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry.Path, directoryName+"/") {
-			return nil, errors.New("Each directory entry must be prefixed with the directoryName")
+			return nil, errors.New("each directory entry must be prefixed with the directoryName")
 		}
 
 		header := &zip.FileHeader{
@@ -635,7 +632,7 @@ func validateCode(code string) error {
 		return err
 	}
 	if strings.Contains(code, " ") {
-		return errors.New("Code must not contain spaces")
+		return errors.New("code must not contain spaces")
 	}
 	return nil
 }

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -625,14 +625,12 @@ func (cc *clientProtocol) Collect(msgTypes ...collectType) (*msgCollector, error
 	return collector, nil
 }
 
-var nonNumericNameplace = errors.New("Non-numeric nameplate")
-
-func nameplaceFromCode(code string) (string, error) {
+func nameplateFromCode(code string) (string, error) {
 	nameplate := strings.SplitN(code, "-", 2)[0]
 
 	_, err := strconv.Atoi(nameplate)
 	if err != nil {
-		return "", nonNumericNameplace
+		return "", errors.New("Non-numeric nameplate")
 	}
 
 	return nameplate, nil

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -110,7 +110,7 @@ type SendResult struct {
 	Error error
 }
 
-var errDecryptFailed = errors.New("Decrypt message failed")
+var errDecryptFailed = errors.New("decrypt message failed")
 
 func openAndUnmarshal(v interface{}, mb rendezvous.MailboxEvent, sharedKey []byte) error {
 	keySlice := derivePhaseKey(string(sharedKey), mb.Side, mb.Phase)
@@ -323,7 +323,7 @@ func (c *msgCollector) close() {
 
 func (c *msgCollector) waitFor(msg collectable) error {
 	if reflect.ValueOf(msg).Kind() != reflect.Ptr {
-		return errors.New("You must pass waitFor a pointer to a struct")
+		return errors.New("you must pass waitFor a pointer to a struct")
 	}
 	sub := collectSubscription{
 		collectMsg: msg,
@@ -389,7 +389,7 @@ func (c *msgCollector) collect(ch <-chan rendezvous.MailboxEvent) {
 			} else {
 				if waiters[collectType] != nil {
 					sub.result <- collectResult{
-						err: errors.New("There is already a pending collect request for this type"),
+						err: errors.New("there is already a pending collect request for this type"),
 					}
 				} else {
 					waiters[collectType] = sub
@@ -406,7 +406,7 @@ func (c *msgCollector) collect(ch <-chan rendezvous.MailboxEvent) {
 			}
 
 			if _, err := strconv.Atoi(gotMsg.Phase); err != nil {
-				errorResult(fmt.Errorf("Got unexpected phase: %s", gotMsg.Phase))
+				errorResult(fmt.Errorf("got unexpected phase: %s", gotMsg.Phase))
 				return
 			}
 
@@ -442,7 +442,7 @@ func (c *msgCollector) collect(ch <-chan rendezvous.MailboxEvent) {
 				delete(waiters, t)
 			} else {
 				if pendingMsgs[t] != nil {
-					errorResult(fmt.Errorf("Got multiple messages of type %s", t))
+					errorResult(fmt.Errorf("got multiple messages of type %s", t))
 					return
 				}
 				pendingMsgs[t] = resultMsg
@@ -509,7 +509,7 @@ func (cc *clientProtocol) ReadPake() error {
 
 func (cc *clientProtocol) Verifier() ([]byte, error) {
 	if cc.sharedKey == nil {
-		return nil, errors.New("Shared key not established yet")
+		return nil, errors.New("shared key not established yet")
 	}
 
 	return deriveVerifier(cc.sharedKey), nil
@@ -560,7 +560,7 @@ func (cc *clientProtocol) openAndUnmarshal(phase string, v interface{}) error {
 	}
 
 	if gotMsg.Phase != phase {
-		return fmt.Errorf("Got unexpected phase while waiting for %s: %s", phase, gotMsg.Phase)
+		return fmt.Errorf("got unexpected phase while waiting for %s: %s", phase, gotMsg.Phase)
 	}
 
 	return openAndUnmarshal(v, gotMsg, cc.sharedKey)
@@ -573,7 +573,7 @@ func (cc *clientProtocol) readPlaintext(phase string, v interface{}) error {
 	}
 
 	if gotMsg.Phase != phase {
-		return fmt.Errorf("Got unexpected phase while waiting for %s: %s", phase, gotMsg.Phase)
+		return fmt.Errorf("got unexpected phase while waiting for %s: %s", phase, gotMsg.Phase)
 	}
 
 	err := jsonHexUnmarshal(gotMsg.Body, &v)
@@ -617,7 +617,7 @@ func (cc *clientProtocol) Collect(msgTypes ...collectType) (*msgCollector, error
 		case collectAnswer:
 			collector.collectAnswer = true
 		default:
-			return nil, fmt.Errorf("Unknown collect msg type %d", msgTypes)
+			return nil, fmt.Errorf("unknown collect msg type %d", msgTypes)
 		}
 	}
 
@@ -630,7 +630,7 @@ func nameplateFromCode(code string) (string, error) {
 
 	_, err := strconv.Atoi(nameplate)
 	if err != nil {
-		return "", errors.New("Non-numeric nameplate")
+		return "", errors.New("non-numeric nameplate")
 	}
 
 	return nameplate, nil

--- a/wormhole/wormhole_test.go
+++ b/wormhole/wormhole_test.go
@@ -17,11 +17,6 @@ import (
 	"github.com/psanford/wormhole-william/rendezvous/rendezvousservertest"
 )
 
-type verifierResult struct {
-	clientID string
-	code     string
-}
-
 func TestWormholeSendRecvText(t *testing.T) {
 	ctx := context.Background()
 
@@ -58,7 +53,7 @@ func TestWormholeSendRecvText(t *testing.T) {
 	nameplate := strings.SplitN(code, "-", 2)[0]
 
 	// recv with wrong code
-	msg, err := c1.Receive(ctx, fmt.Sprintf("%s-intermarrying-aliased", nameplate))
+	_, err = c1.Receive(ctx, fmt.Sprintf("%s-intermarrying-aliased", nameplate))
 	if err != errDecryptFailed {
 		t.Fatalf("Recv side expected decrypt failed due to wrong code but got: %s", err)
 	}
@@ -74,7 +69,7 @@ func TestWormholeSendRecvText(t *testing.T) {
 	}
 
 	// recv with correct code
-	msg, err = c1.Receive(ctx, code)
+	msg, err := c1.Receive(ctx, code)
 	if err != nil {
 		t.Fatalf("Recv side got unexpected err: %s", err)
 	}


### PR DESCRIPTION
This PR does two things:
1. There seems to be some incorrect wording using "nameplace" instead of "nameplate". I corrected it.
2. It adds a lot of changes for issues reported by staticcheck. Removing unused stuff and keeping error strings non capitalized to stick with standard Go procedures.