### PR TITLE
Switch zip handling to github.com/klauspost/compress/zip

### DIFF
--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"archive/zip"
 	"bufio"
 	"context"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/cheggaaa/pb/v3"
+	"github.com/klauspost/compress/zip"
 	"github.com/psanford/wormhole-william/wormhole"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/cheggaaa/pb/v3 v3.0.1
 	github.com/gorilla/websocket v1.4.2
+	github.com/klauspost/compress v1.11.4
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
 	salsa.debian.org/vasudev/gospake2 v0.0.0-20180813171123-adcc69dd31d5

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/klauspost/compress v1.11.4 h1:kz40R/YWls3iqT9zX9AHN3WoVsrAWVyui5sxuLqiXqU=
+github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/wormhole/send.go
+++ b/wormhole/send.go
@@ -1,7 +1,6 @@
 package wormhole
 
 import (
-	"archive/zip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -14,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/klauspost/compress/zip"
 	"github.com/psanford/wormhole-william/internal/crypto"
 	"github.com/psanford/wormhole-william/rendezvous"
 	"github.com/psanford/wormhole-william/wordlist"

--- a/wormhole/wormhole_test.go
+++ b/wormhole/wormhole_test.go
@@ -1,7 +1,6 @@
 package wormhole
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/hex"
@@ -15,6 +14,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/klauspost/compress/zip"
 	"github.com/psanford/wormhole-william/rendezvous/rendezvousservertest"
 )
 
@@ -137,7 +137,7 @@ func TestWormholeSendRecvText(t *testing.T) {
 	}
 
 	if progressCallCount != 1 {
-		t.Fatalf("progressCallCount got %d expected 1",progressCallCount)
+		t.Fatalf("progressCallCount got %d expected 1", progressCallCount)
 	}
 
 	if progressSentBytes != int64(len(msgBody)) {


### PR DESCRIPTION
This significantly improves the performance. My testing indicates that archiving is up to about about 2.5x faster and unarchiving around 1.3x faster.