### PR TITLE
cmd: Fix dir send on Windows when the given path use / over \

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -156,9 +156,7 @@ func sendDir(dirpath string) {
 	var entries []wormhole.DirectoryEntry
 
 	filepath.Walk(dirpath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		} else if info.IsDir() || !info.Mode().IsRegular() {
+		if info.IsDir() || !info.Mode().IsRegular() {
 			return nil
 		}
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/cheggaaa/pb/v3"
@@ -155,18 +156,18 @@ func sendDir(dirpath string) {
 	var entries []wormhole.DirectoryEntry
 
 	filepath.Walk(dirpath, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
+		if err != nil {
+			return err
+		} else if info.IsDir() || !info.Mode().IsRegular() {
 			return nil
 		}
 
-		if !info.Mode().IsRegular() {
-			return nil
+		if runtime.GOOS == "windows" {
+			path = filepath.ToSlash(path)
 		}
-
-		relPath := strings.TrimPrefix(path, prefix)
 
 		entries = append(entries, wormhole.DirectoryEntry{
-			Path: relPath,
+			Path: strings.TrimPrefix(path, prefix),
 			Mode: info.Mode(),
 			Reader: func() (io.ReadCloser, error) {
 				return os.Open(path)


### PR DESCRIPTION
I was noticing, in wormhole-gui, that sending directories on Windows always failed with an error. After some debugging, it turns out that filepath.Walk calls the path with "\\", but if the given path contains forward slashes, calling `filepath.TrimPrefix` will fail. You might say that this PR makes it possible to use “/“ when used on Windows and is thus perhaps more of a feature than a bug fix. If you don’t want to add this, I won’t complain.

It also features a minor cleanup inside the `filepath.Walk` function. I figured that I would open a PR upstream as the same issue can be found in the command line utility. Merry Christmas :christmas_tree: 