### PR TITLE
sendFileDirectory: cancel transfers via context

### DIFF
--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"log"
 
 	"github.com/psanford/wormhole-william/internal/crypto"
 	"github.com/psanford/wormhole-william/rendezvous"
@@ -347,7 +346,6 @@ func (f *IncomingMessage) readCrypt(p []byte) (int, error) {
 	if len(f.buf) == 0 {
 		rec, err := f.cryptor.readRecord()
 		if err == io.EOF {
-			log.Printf("unexpected eof! reclen=%d totallen=%d", len(rec), f.readCount)
 			f.readErr = io.ErrUnexpectedEOF
 			return 0, f.readErr
 		} else if err != nil {

--- a/wormhole/send.go
+++ b/wormhole/send.go
@@ -373,6 +373,15 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 			totalSize = offer.Directory.ZipSize
 		}
 
+		var cancel func()
+		ctx, cancel = context.WithCancel(ctx)
+		defer cancel()
+
+		go func() {
+			<-ctx.Done()
+			conn.Close()
+		}()
+
 		for {
 			n, err := r.Read(recordSlice)
 			if n > 0 {


### PR DESCRIPTION
Canceling the context will now cancel an in-flight file transfer.
This should cover most cases. There might still be some edge cases
where cancellation doesn't work.

Fixes #11 