### PR TITLE
Add meta tests for gofmt and mod tidy

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Build
+    name: Build/Test
     runs-on: ${{ matrix.os }}
     timeout-minutes: 3
     strategy:
@@ -26,6 +26,10 @@ jobs:
 
     - name: Test
       run: go test -v ./... --timeout 60s
+
+    - name: Meta Tests
+      run: go test -v -tags ci ./ci --timeout 60s
+      if: ${{ runner.os == 'Linux' }}
 
     - name: Cross test for i386
       run: env GOOS=linux GOARCH=386 go test -v ./... --timeout 60s

--- a/ci/gofmt_test.go
+++ b/ci/gofmt_test.go
@@ -1,0 +1,61 @@
+// +build ci
+
+package ci
+
+import (
+	"bytes"
+	"go/format"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGofmt(t *testing.T) {
+	var (
+		needsFormatting []string
+		checkedFiles    int
+	)
+
+	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if path == ".git" {
+			return filepath.SkipDir
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		formatted, err := format.Source(content)
+		if err != nil {
+			return err
+		}
+
+		if !bytes.Equal(content, formatted) {
+			needsFormatting = append(needsFormatting, strings.TrimPrefix(path, ".."))
+		}
+
+		checkedFiles++
+
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(needsFormatting) > 0 {
+		t.Fatalf("The following files are not properlery gofmt'ed: %v", needsFormatting)
+	}
+
+	if checkedFiles < 20 {
+		t.Fatalf("Expected to check at least 20 files but only checked %d", checkedFiles)
+	}
+}

--- a/ci/gomodtidy_test.go
+++ b/ci/gomodtidy_test.go
@@ -1,0 +1,61 @@
+// +build ci
+
+package ci
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestGoModTidy(t *testing.T) {
+	modified, err := modifiedFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(modified) > 0 {
+		t.Fatalf("Modified files detected before running `go mod tidy`: \n%s", strings.Join(modified, "\n"))
+	}
+
+	output, err := exec.Command("go", "mod", "tidy").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go mod tidy err: %s %s", err, output)
+	}
+
+	modified, err = modifiedFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(modified) > 0 {
+		t.Fatalf("Modified files detected from running `go mod tidy`: %v", modified)
+	}
+}
+
+func modifiedFiles() ([]string, error) {
+	var modifiedFiles []string
+
+	status, err := exec.Command("git", "status", "-s").CombinedOutput()
+	if err != nil {
+		fmt.Printf("%s\n", status)
+		return nil, err
+	}
+
+	lines := bytes.Split(status, []byte("\n"))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("??")) {
+			// ignore untracked files
+			continue
+		}
+		modifiedFiles = append(modifiedFiles, string(line))
+	}
+
+	return modifiedFiles, nil
+}


### PR DESCRIPTION
These tests make sure files are all gofmt'ed and that a `go mod tidy`
doesn't produce any changes to the `go.mod` or `go.sum` files.

I want this information exposed in PRs.

The go mod tidy test is behind the `ci` build tag. This is because
that test looks at the git working tree state and will also update
the go.mod/sum files if it needs to, which could be quite annoying
during development.