### PR TITLE
Handle context cancels of pending connections

### DIFF
--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -57,7 +57,7 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 		return nil, err
 	}
 
-	err = clientProto.ReadPake()
+	err = clientProto.ReadPake(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/wormhole/send.go
+++ b/wormhole/send.go
@@ -95,7 +95,7 @@ func (c *Client) SendText(ctx context.Context, msg string, opts ...SendOption) (
 			return
 		}
 
-		err = clientProto.ReadPake()
+		err = clientProto.ReadPake(ctx)
 		if err != nil {
 			sendErr(err)
 			return
@@ -257,7 +257,7 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 			return
 		}
 
-		err = clientProto.ReadPake()
+		err = clientProto.ReadPake(ctx)
 		if err != nil {
 			sendErr(err)
 			return

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -499,9 +499,9 @@ func (cc *clientProtocol) WritePake(ctx context.Context, code string) error {
 	return cc.rc.AddMessage(ctx, "pake", jsonHexMarshal(pm))
 }
 
-func (cc *clientProtocol) ReadPake() error {
+func (cc *clientProtocol) ReadPake(ctx context.Context) error {
 	var pake pakeMsg
-	err := cc.readPlaintext("pake", &pake)
+	err := cc.readPlaintext(ctx, "pake", &pake)
 	if err != nil {
 		return err
 	}
@@ -580,8 +580,13 @@ func (cc *clientProtocol) openAndUnmarshal(phase string, v interface{}) error {
 	return openAndUnmarshal(v, gotMsg, cc.sharedKey)
 }
 
-func (cc *clientProtocol) readPlaintext(phase string, v interface{}) error {
-	gotMsg := <-cc.ch
+func (cc *clientProtocol) readPlaintext(ctx context.Context, phase string, v interface{}) error {
+	var gotMsg rendezvous.MailboxEvent
+	select {
+	case gotMsg = <-cc.ch:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 	if gotMsg.Error != nil {
 		return gotMsg.Error
 	}


### PR DESCRIPTION
Previously if one side attempted to connect and the other side never
joined, the client would block waiting for rendezvous messages and
canceling would do nothing.

Now if the client is waiting for a message from the rendezvous server,
a context cancel will unblock the client and trigger an error.