### PR TITLE
Omit-empty non-applicable answer msgs

### DIFF
--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -246,8 +246,8 @@ type appVersionsMsg struct {
 }
 
 type answerMsg struct {
-	MessageAck string `json:"message_ack"`
-	FileAck    string `json:"file_ack"`
+	MessageAck string `json:"message_ack,omitempty"`
+	FileAck    string `json:"file_ack,omitempty"`
 }
 
 func (m *answerMsg) Type() collectType {


### PR DESCRIPTION
There's no need to send empty string fields for answers that would be
used in other types of responses.

The rust wormhole client was unhappy with the extra fields in these
messages.

Fixes #59