### PR TITLE
Text receives now update TransferBytes and UncompressedBytes, fixes #56

### DIFF
--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -1,7 +1,6 @@
 package wormhole
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -10,6 +9,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"strings"
 
 	"github.com/psanford/wormhole-william/internal/crypto"
 	"github.com/psanford/wormhole-william/rendezvous"
@@ -119,8 +119,14 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 
 		rc.Close(ctx, rendezvous.Happy)
 
+		text := *offer.Message
+		fr.TransferBytes = len(text)
+		fr.TransferBytes64 = int64(fr.TransferBytes)
+		fr.UncompressedBytes = fr.TransferBytes
+		fr.UncompressedBytes64 = fr.TransferBytes64
+
 		fr.Type = TransferText
-		fr.textReader = bytes.NewReader([]byte(*offer.Message))
+		fr.textReader = strings.NewReader(text)
 		return fr, nil
 	} else if offer.File != nil {
 		fr.Type = TransferFile


### PR DESCRIPTION
This commit makes sure that also text receives say how long the content is.
I have tested this in wormhole-gui and it works just as expected :)

Fixes #56