### PR TITLE
Update wormhole-gui mention to use rymdport

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,5 +133,5 @@ See the [cli tool](https://github.com/psanford/wormhole-william/tree/master/cmd)
 
 ## Third Party Users of Wormhole William
 
-- [wormhole-gui](https://github.com/Jacalz/wormhole-gui): A Magic Wormhole graphical user interface
+- [rymdport](https://github.com/Jacalz/rymdport): A cross-platform Magic Wormhole graphical user interface
 - [wormhole-william-mobile](https://github.com/psanford/wormhole-william-mobile): Android wormhole-william app


### PR DESCRIPTION
Update the README reference to use the new name for wormhole-gui. I also added cross-platform to be a little more in line with my project documentation.