### PR TITLE
Use hex.EncodeToString for faster hex encoding

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -2,7 +2,7 @@ package crypto
 
 import (
 	"crypto/rand"
-	"fmt"
+	"encoding/hex"
 	"io"
 )
 
@@ -21,7 +21,7 @@ func RandHex(byteCount int) string {
 		panic(err)
 	}
 
-	return fmt.Sprintf("%x", buf)
+	return hex.EncodeToString(buf)
 }
 
 func RandNonce() [NonceSize]byte {

--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -391,7 +391,7 @@ func (f *IncomingMessage) readCrypt(p []byte) (int, error) {
 		sum := f.sha256.Sum(nil)
 		ack := fileTransportAck{
 			Ack:    "ok",
-			SHA256: fmt.Sprintf("%x", sum),
+			SHA256: hex.EncodeToString(sum),
 		}
 
 		msg, _ := json.Marshal(ack)

--- a/wormhole/send.go
+++ b/wormhole/send.go
@@ -424,7 +424,7 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 			return
 		}
 
-		shaSum := fmt.Sprintf("%x", hasher.Sum(nil))
+		shaSum := hex.EncodeToString(hasher.Sum(nil))
 		if strings.ToLower(ack.SHA256) != shaSum {
 			sendErr(fmt.Errorf("receiver sha256 mismatch %s vs %s", ack.SHA256, shaSum))
 			return


### PR DESCRIPTION
Benchmarks indicate the encoding is 35% faster and allocates 30% less memory.
There were a few places in https://github.com/psanford/wormhole-william/blob/cb9dbf21814d1cbebc487b9471a32f5cae195cca/wormhole/file_transport.go that could also be switched over but the string concatenation resulted in the old way being faster for those. 