### PR TITLE
cmd: optimize how text receives are printed

### DIFF
--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -69,12 +69,13 @@ func recvAction(cmd *cobra.Command, args []string) {
 
 	switch msg.Type {
 	case wormhole.TransferText:
-		body, err := ioutil.ReadAll(msg)
+		text := make([]byte, int(msg.TransferBytes64))
+		_, err := io.ReadFull(msg, text)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		fmt.Println(string(body))
+		fmt.Println(string(text))
 	case wormhole.TransferFile:
 		var acceptFile bool
 		if _, err := os.Stat(msg.Name); err == nil {

--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -69,13 +69,15 @@ func recvAction(cmd *cobra.Command, args []string) {
 
 	switch msg.Type {
 	case wormhole.TransferText:
-		text := make([]byte, int(msg.TransferBytes64))
-		_, err := io.ReadFull(msg, text)
+		_, err := io.Copy(os.Stdout, msg)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		fmt.Println(string(text))
+		_, err = os.Stdout.WriteString("\n")
+		if err != nil {
+			log.Fatal(err)
+		}
 	case wormhole.TransferFile:
 		var acceptFile bool
 		if _, err := os.Stat(msg.Name); err == nil {


### PR DESCRIPTION
Now that we know the length of the text, we can use ReadFull() with a pre-allocated buffer instead.
ReadAll always allocates 512 bytes minimum and will append as it goes. We now just allocate just as much as needed and do so once only.

I did this for Rymdport as well and figured that it wouldn't hurt being a good open source citizen and improve it here also :)