### PR TITLE
Handle empty file transfers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        go-version: [1.16.12, 1.17.5, 1.18beta1]
+        go-version: [1.17.10, 1.18.2]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -369,7 +369,12 @@ func (f *IncomingMessage) readCrypt(p []byte) (int, error) {
 		}
 	}
 
-	if len(f.buf) == 0 {
+	// for empty files the sender doesn't send any records
+	// so we need to short circut the read and proceed straight
+	// to sending an "ok" ack
+	emptyFile := f.TransferBytes64 == 0
+
+	if len(f.buf) == 0 && !emptyFile {
 		rec, err := f.cryptor.readRecord()
 		if err == io.EOF {
 			f.readErr = io.ErrUnexpectedEOF


### PR DESCRIPTION
Previously we would hang on receiving an empty file because we
expected to get at least one record. The python implementation short
circuits the read if the offer says the length is 0, so we now do that
also.

Fixes #78