### PR TITLE
Update build script to build for more architectures, fixes #77

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.5"
+          go-version: "1.18.3"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18.3"
+          go-version: "1.19.0"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.19.0"
+          go-version: "1.19.4"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build Artifacts

--- a/build_release.go
+++ b/build_release.go
@@ -94,6 +94,10 @@ var targets = []target{
 	{"linux", "arm", "6"},
 	{"linux", "arm", "7"},
 	{"darwin", "amd64", ""},
+	{"darwin", "arm64", ""},
+	{"windows", "amd64", ""},
+	{"windows", "arm64", ""},
 	{"windows", "386", ""},
 	{"freebsd", "amd64", ""},
+	{"freebsd", "arm64", ""},
 }

--- a/build_release.go
+++ b/build_release.go
@@ -96,8 +96,8 @@ var targets = []target{
 	{"darwin", "amd64", ""},
 	{"darwin", "arm64", ""},
 	{"windows", "amd64", ""},
-	{"windows", "arm64", ""},
+	//{"windows", "arm64", ""},
 	{"windows", "386", ""},
 	{"freebsd", "amd64", ""},
-	{"freebsd", "arm64", ""},
+	//{"freebsd", "arm64", ""},
 }

--- a/build_release.go
+++ b/build_release.go
@@ -96,8 +96,6 @@ var targets = []target{
 	{"darwin", "amd64", ""},
 	{"darwin", "arm64", ""},
 	{"windows", "amd64", ""},
-	//{"windows", "arm64", ""},
 	{"windows", "386", ""},
 	{"freebsd", "amd64", ""},
-	//{"freebsd", "arm64", ""},
 }


### PR DESCRIPTION
This PR updates the build script to build `arm64` binaires for ~~FreeBSD~~, macOS and ~~Windows~~. It also makes sure to add `amd64` binaries to Windows. Lastly, the release action got updated to use the new Go 1.18.3 version for register based calling convention on arm64 as well as some security fixes.

Fixes #77

~~Release builds now also strip the DWARF data from binaries. This means that release binaries go from being 10MB to being 7MB instead.~~