### PR TITLE
Drop reflection in rendezvous/client.go

### DIFF
--- a/rendezvous/client.go
+++ b/rendezvous/client.go
@@ -206,7 +206,7 @@ func (c *Client) deregisterWaiter(id uint32) {
 	delete(c.pendingMsgWaiters, id)
 }
 
-func (c *Client) readMsg(ctx context.Context, m interface{}) error {
+func (c *Client) readMsg(ctx context.Context, m msgs.RendezvousValue) error {
 	expectMsgType := msgType(m)
 
 	waiterID, ch := c.registerWaiter()
@@ -233,22 +233,8 @@ func (c *Client) readMsg(ctx context.Context, m interface{}) error {
 	}
 }
 
-func msgType(msg interface{}) string {
-	ptr := reflect.TypeOf(msg)
-
-	if ptr.Kind() != reflect.Ptr {
-		panic("msg must be a pointer")
-	}
-
-	structType := ptr.Elem()
-
-	for i := 0; i < structType.NumField(); i++ {
-		field := structType.Field(i)
-		if field.Tag.Get("json") == "type" {
-			return field.Tag.Get("rendezvous_value")
-		}
-	}
-	return ""
+func msgType(msg msgs.RendezvousValue) string {
+	return msg.RendezvousValue()
 }
 
 // CreateMailbox allocates a nameplate, claims it, and then opens

--- a/rendezvous/client.go
+++ b/rendezvous/client.go
@@ -207,7 +207,7 @@ func (c *Client) deregisterWaiter(id uint32) {
 }
 
 func (c *Client) readMsg(ctx context.Context, m msgs.RendezvousValue) error {
-	expectMsgType := msgType(m)
+	expectMsgType := m.RendezvousValue()
 
 	waiterID, ch := c.registerWaiter()
 	defer c.deregisterWaiter(waiterID)
@@ -231,10 +231,6 @@ func (c *Client) readMsg(ctx context.Context, m msgs.RendezvousValue) error {
 			return nil
 		}
 	}
-}
-
-func msgType(msg msgs.RendezvousValue) string {
-	return msg.RendezvousValue()
 }
 
 // CreateMailbox allocates a nameplate, claims it, and then opens

--- a/rendezvous/client.go
+++ b/rendezvous/client.go
@@ -278,7 +278,6 @@ func (c *Client) AttachMailbox(ctx context.Context, nameplate string) error {
 // ListNameplates returns a list of active nameplates on the
 // rendezvous server.
 func (c *Client) ListNameplates(ctx context.Context) ([]string, error) {
-	nameplatesResp := msgs.NewNameplates()
 	listReq := msgs.NewList()
 
 	_, err := c.sendAndWait(ctx, listReq)
@@ -286,6 +285,7 @@ func (c *Client) ListNameplates(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
+	nameplatesResp := msgs.NewNameplates()
 	err = c.readMsg(ctx, nameplatesResp)
 	if err != nil {
 		return nil, err

--- a/rendezvous/client.go
+++ b/rendezvous/client.go
@@ -462,7 +462,7 @@ func (c *Client) agentID() (string, string) {
 func (c *Client) bind(ctx context.Context, side, appID string) error {
 	agent, version := c.agentID()
 
-	bind := msgs.NewBind(side, appID, []string{agent, version})
+	bind := msgs.NewBind(side, appID, [2]string{agent, version})
 	_, err := c.sendAndWait(ctx, bind)
 	return err
 }

--- a/rendezvous/internal/msgs/msgs.go
+++ b/rendezvous/internal/msgs/msgs.go
@@ -7,6 +7,10 @@ type Welcome struct {
 	ServerTX float64           `json:"server_tx"`
 }
 
+func (w *Welcome) RendezvousValue() string {
+	return "welcome"
+}
+
 type WelcomeServerInfo struct {
 	MOTD              string `json:"motd"`
 	CurrentCLIVersion string `json:"current_cli_version"`
@@ -24,10 +28,18 @@ type Bind struct {
 	ClientVersion []string `json:"client_version"`
 }
 
+func (b *Bind) RendezvousValue() string {
+	return "bind"
+}
+
 // Client sent aollocate message
 type Allocate struct {
 	Type string `json:"type" rendezvous_value:"allocate"`
 	ID   string `json:"id"`
+}
+
+func (a *Allocate) RendezvousValue() string {
+	return "allocate"
 }
 
 // Server sent ack message
@@ -37,11 +49,19 @@ type Ack struct {
 	ServerTX float64 `json:"server_tx"`
 }
 
+func (a *Ack) RendezvousValue() string {
+	return "ack"
+}
+
 // Server sent allocated message
 type AllocatedResp struct {
 	Type      string  `json:"type" rendezvous_value:"allocated"`
 	Nameplate string  `json:"nameplate"`
 	ServerTX  float64 `json:"server_tx"`
+}
+
+func (a *AllocatedResp) RendezvousValue() string {
+	return "allocated"
 }
 
 // Client sent claim message
@@ -51,11 +71,19 @@ type Claim struct {
 	Nameplate string `json:"nameplate"`
 }
 
+func (c *Claim) RendezvousValue() string {
+	return "claim"
+}
+
 // Server sent claimed message
 type ClaimedResp struct {
 	Type     string  `json:"type" rendezvous_value:"claimed"`
 	Mailbox  string  `json:"mailbox"`
 	ServerTX float64 `json:"server_tx"`
+}
+
+func (c *ClaimedResp) RendezvousValue() string {
+	return "claimed"
 }
 
 // Client sent open message
@@ -65,6 +93,10 @@ type Open struct {
 	Mailbox string `json:"mailbox"`
 }
 
+func (o *Open) RendezvousValue() string {
+	return "open"
+}
+
 // Client sent add message to add a message to a mailbox.
 type Add struct {
 	Type  string `json:"type" rendezvous_value:"add"`
@@ -72,6 +104,10 @@ type Add struct {
 	Phase string `json:"phase"`
 	// Body is a hex string encoded json submessage
 	Body string `json:"body"`
+}
+
+func (a *Add) RendezvousValue() string {
+	return "add"
 }
 
 // Server sent message message
@@ -86,10 +122,18 @@ type Message struct {
 	ServerTX float64 `json:"server_tx"`
 }
 
+func (m *Message) RendezvousValue() string {
+	return "message"
+}
+
 // Client sent list message to list nameplates.
 type List struct {
 	Type string `json:"type" rendezvous_value:"list"`
 	ID   string `json:"id"`
+}
+
+func (l *List) RendezvousValue() string {
+	return "list"
 }
 
 // Server sent nameplates message.
@@ -103,6 +147,10 @@ type Nameplates struct {
 	ServerTX float64 `json:"server_tx"`
 }
 
+func (n *Nameplates) RendezvousValue() string {
+	return "nameplates"
+}
+
 // Client sent release message to release a nameplate.
 type Release struct {
 	Type      string `json:"type" rendezvous_value:"release"`
@@ -110,10 +158,18 @@ type Release struct {
 	Nameplate string `json:"nameplate"`
 }
 
+func (r *Release) RendezvousValue() string {
+	return "release"
+}
+
 // Server sent response to release request.
 type ReleasedResp struct {
 	Type     string  `json:"type" rendezvous_value:"released"`
 	ServerTX float64 `json:"server_tx"`
+}
+
+func (r *ReleasedResp) RendezvousValue() string {
+	return "released"
 }
 
 // Server sent error message
@@ -124,6 +180,10 @@ type Error struct {
 	ServerTx float64     `json:"server_tx"`
 }
 
+func (e *Error) RendezvousValue() string {
+	return "error"
+}
+
 type Close struct {
 	Type    string `json:"type" rendezvous_value:"close"`
 	ID      string `json:"id"`
@@ -131,9 +191,17 @@ type Close struct {
 	Mood    string `json:"mood"`
 }
 
+func (c *Close) RendezvousValue() string {
+	return "close"
+}
+
 type ClosedResp struct {
 	Type     string  `json:"type" rendezvous_value:"closed"`
 	ServerTx float64 `json:"server_tx"`
+}
+
+func (c *ClosedResp) RendezvousValue() string {
+	return "closed"
 }
 
 type GenericServerMsg struct {
@@ -141,24 +209,4 @@ type GenericServerMsg struct {
 	ServerTX float64 `json:"server_tx"`
 	ID       string  `json:"id"`
 	Error    string  `json:"error"`
-}
-
-var MsgMap = map[string]interface{}{
-	"welcome":    Welcome{},
-	"bind":       Bind{},
-	"allocate":   Allocate{},
-	"ack":        Ack{},
-	"allocated":  AllocatedResp{},
-	"claim":      Claim{},
-	"claimed":    ClaimedResp{},
-	"open":       Open{},
-	"add":        Add{},
-	"message":    Message{},
-	"list":       List{},
-	"nameplates": Nameplates{},
-	"release":    Release{},
-	"released":   ReleasedResp{},
-	"error":      Error{},
-	"close":      Close{},
-	"closed":     ClosedResp{},
 }

--- a/rendezvous/internal/msgs/msgs.go
+++ b/rendezvous/internal/msgs/msgs.go
@@ -25,7 +25,7 @@ type WelcomeServerInfo struct {
 	Error             string `json:"error"`
 }
 
-func NewBind(side, appid string, clientVersion []string) *Bind {
+func NewBind(side, appid string, clientVersion [2]string) *Bind {
 	return &Bind{
 		Type:          "bind",
 		ID:            crypto.RandHex(2),
@@ -43,7 +43,7 @@ type Bind struct {
 	AppID string `json:"appid"`
 	// ClientVersion is by convention a two value array
 	// of [client_id, version]
-	ClientVersion []string `json:"client_version"`
+	ClientVersion [2]string `json:"client_version"`
 }
 
 func (b *Bind) GetType() string {

--- a/rendezvous/internal/msgs/msgs.go
+++ b/rendezvous/internal/msgs/msgs.go
@@ -1,5 +1,13 @@
 package msgs
 
+import "github.com/psanford/wormhole-william/internal/crypto"
+
+func NewWelcome() *Welcome {
+	return &Welcome{
+		Type: "welcome",
+	}
+}
+
 // Server sent wecome message
 type Welcome struct {
 	Type     string            `json:"type" rendezvous_value:"welcome"`
@@ -7,14 +15,24 @@ type Welcome struct {
 	ServerTX float64           `json:"server_tx"`
 }
 
-func (w *Welcome) RendezvousValue() string {
-	return "welcome"
+func (w *Welcome) GetType() string {
+	return w.Type
 }
 
 type WelcomeServerInfo struct {
 	MOTD              string `json:"motd"`
 	CurrentCLIVersion string `json:"current_cli_version"`
 	Error             string `json:"error"`
+}
+
+func NewBind(side, appid string, clientVersion []string) *Bind {
+	return &Bind{
+		Type:          "bind",
+		ID:            crypto.RandHex(2),
+		Side:          side,
+		AppID:         appid,
+		ClientVersion: clientVersion,
+	}
 }
 
 // Client sent bind message
@@ -28,8 +46,19 @@ type Bind struct {
 	ClientVersion []string `json:"client_version"`
 }
 
-func (b *Bind) RendezvousValue() string {
-	return "bind"
+func (b *Bind) GetType() string {
+	return b.Type
+}
+
+func (b *Bind) GetID() string {
+	return b.ID
+}
+
+func NewAllocate() *Allocate {
+	return &Allocate{
+		Type: "allocate",
+		ID:   crypto.RandHex(2),
+	}
 }
 
 // Client sent aollocate message
@@ -38,8 +67,19 @@ type Allocate struct {
 	ID   string `json:"id"`
 }
 
-func (a *Allocate) RendezvousValue() string {
-	return "allocate"
+func (a *Allocate) GetType() string {
+	return a.Type
+}
+
+func (a *Allocate) GetID() string {
+	return a.ID
+}
+
+func NewAck() *Ack {
+	return &Ack{
+		Type: "ack",
+		ID:   crypto.RandHex(2),
+	}
 }
 
 // Server sent ack message
@@ -49,8 +89,18 @@ type Ack struct {
 	ServerTX float64 `json:"server_tx"`
 }
 
-func (a *Ack) RendezvousValue() string {
-	return "ack"
+func (a *Ack) GetType() string {
+	return a.Type
+}
+
+func (a *Ack) GetID() string {
+	return a.ID
+}
+
+func NewAllocatedResp() *AllocatedResp {
+	return &AllocatedResp{
+		Type: "allocated",
+	}
 }
 
 // Server sent allocated message
@@ -60,8 +110,16 @@ type AllocatedResp struct {
 	ServerTX  float64 `json:"server_tx"`
 }
 
-func (a *AllocatedResp) RendezvousValue() string {
-	return "allocated"
+func (a *AllocatedResp) GetType() string {
+	return a.Type
+}
+
+func NewClaim(nameplate string) *Claim {
+	return &Claim{
+		Type:      "claim",
+		ID:        crypto.RandHex(2),
+		Nameplate: nameplate,
+	}
 }
 
 // Client sent claim message
@@ -71,8 +129,18 @@ type Claim struct {
 	Nameplate string `json:"nameplate"`
 }
 
-func (c *Claim) RendezvousValue() string {
-	return "claim"
+func (c *Claim) GetType() string {
+	return c.Type
+}
+
+func (c *Claim) GetID() string {
+	return c.ID
+}
+
+func NewClaimedResp() *ClaimedResp {
+	return &ClaimedResp{
+		Type: "claimed",
+	}
 }
 
 // Server sent claimed message
@@ -82,8 +150,16 @@ type ClaimedResp struct {
 	ServerTX float64 `json:"server_tx"`
 }
 
-func (c *ClaimedResp) RendezvousValue() string {
-	return "claimed"
+func (c *ClaimedResp) GetType() string {
+	return c.Type
+}
+
+func NewOpen(mailbox string) *Open {
+	return &Open{
+		Type:    "open",
+		ID:      crypto.RandHex(2),
+		Mailbox: mailbox,
+	}
 }
 
 // Client sent open message
@@ -93,8 +169,21 @@ type Open struct {
 	Mailbox string `json:"mailbox"`
 }
 
-func (o *Open) RendezvousValue() string {
-	return "open"
+func (o *Open) GetType() string {
+	return o.Type
+}
+
+func (o *Open) GetID() string {
+	return o.ID
+}
+
+func NewAdd(phase, body string) *Add {
+	return &Add{
+		Type:  "add",
+		ID:    crypto.RandHex(2),
+		Phase: phase,
+		Body:  body,
+	}
 }
 
 // Client sent add message to add a message to a mailbox.
@@ -106,8 +195,19 @@ type Add struct {
 	Body string `json:"body"`
 }
 
-func (a *Add) RendezvousValue() string {
-	return "add"
+func (a *Add) GetType() string {
+	return a.Type
+}
+
+func (a *Add) GetID() string {
+	return a.ID
+}
+
+func NewMessage() *Message {
+	return &Message{
+		Type: "message",
+		ID:   crypto.RandHex(2),
+	}
 }
 
 // Server sent message message
@@ -122,8 +222,19 @@ type Message struct {
 	ServerTX float64 `json:"server_tx"`
 }
 
-func (m *Message) RendezvousValue() string {
-	return "message"
+func (m *Message) GetType() string {
+	return m.Type
+}
+
+func (m *Message) GetID() string {
+	return m.ID
+}
+
+func NewList() *List {
+	return &List{
+		Type: "list",
+		ID:   crypto.RandHex(2),
+	}
 }
 
 // Client sent list message to list nameplates.
@@ -132,8 +243,18 @@ type List struct {
 	ID   string `json:"id"`
 }
 
-func (l *List) RendezvousValue() string {
-	return "list"
+func (l *List) GetType() string {
+	return l.Type
+}
+
+func (l *List) GetID() string {
+	return l.ID
+}
+
+func NewNameplates() *Nameplates {
+	return &Nameplates{
+		Type: "nameplates",
+	}
 }
 
 // Server sent nameplates message.
@@ -147,8 +268,16 @@ type Nameplates struct {
 	ServerTX float64 `json:"server_tx"`
 }
 
-func (n *Nameplates) RendezvousValue() string {
-	return "nameplates"
+func (n *Nameplates) GetType() string {
+	return n.Type
+}
+
+func NewRelease(nameplate string) *Release {
+	return &Release{
+		Type:      "release",
+		ID:        crypto.RandHex(2),
+		Nameplate: nameplate,
+	}
 }
 
 // Client sent release message to release a nameplate.
@@ -158,8 +287,18 @@ type Release struct {
 	Nameplate string `json:"nameplate"`
 }
 
-func (r *Release) RendezvousValue() string {
-	return "release"
+func (r *Release) GetType() string {
+	return r.Type
+}
+
+func (r *Release) GetID() string {
+	return r.ID
+}
+
+func NewReleasedResp() *ReleasedResp {
+	return &ReleasedResp{
+		Type: "released",
+	}
 }
 
 // Server sent response to release request.
@@ -168,8 +307,16 @@ type ReleasedResp struct {
 	ServerTX float64 `json:"server_tx"`
 }
 
-func (r *ReleasedResp) RendezvousValue() string {
-	return "released"
+func (r *ReleasedResp) GetType() string {
+	return r.Type
+}
+
+func NewError(errorStr string, orig interface{}) *Error {
+	return &Error{
+		Type:  "error",
+		Error: errorStr,
+		Orig:  orig,
+	}
 }
 
 // Server sent error message
@@ -180,8 +327,17 @@ type Error struct {
 	ServerTx float64     `json:"server_tx"`
 }
 
-func (e *Error) RendezvousValue() string {
-	return "error"
+func (e *Error) GetType() string {
+	return e.Type
+}
+
+func NewClose(mood, mailbox string) *Close {
+	return &Close{
+		Type:    "close",
+		ID:      crypto.RandHex(2),
+		Mood:    mood,
+		Mailbox: mailbox,
+	}
 }
 
 type Close struct {
@@ -191,8 +347,18 @@ type Close struct {
 	Mood    string `json:"mood"`
 }
 
-func (c *Close) RendezvousValue() string {
-	return "close"
+func (c *Close) GetType() string {
+	return c.Type
+}
+
+func (c *Close) GetID() string {
+	return c.ID
+}
+
+func NewClosedResp() *ClosedResp {
+	return &ClosedResp{
+		Type: "closed",
+	}
 }
 
 type ClosedResp struct {
@@ -200,8 +366,8 @@ type ClosedResp struct {
 	ServerTx float64 `json:"server_tx"`
 }
 
-func (c *ClosedResp) RendezvousValue() string {
-	return "closed"
+func (c *ClosedResp) GetType() string {
+	return c.Type
 }
 
 type GenericServerMsg struct {
@@ -209,4 +375,8 @@ type GenericServerMsg struct {
 	ServerTX float64 `json:"server_tx"`
 	ID       string  `json:"id"`
 	Error    string  `json:"error"`
+}
+
+func (g *GenericServerMsg) GetID() string {
+	return g.ID
 }

--- a/rendezvous/internal/msgs/msgs_test.go
+++ b/rendezvous/internal/msgs/msgs_test.go
@@ -4,29 +4,29 @@ import (
 	"testing"
 )
 
-var msgMap = map[string]RendezvousValue{
-	"welcome":    &Welcome{},
-	"bind":       &Bind{},
-	"allocate":   &Allocate{},
-	"ack":        &Ack{},
-	"allocated":  &AllocatedResp{},
-	"claim":      &Claim{},
-	"claimed":    &ClaimedResp{},
-	"open":       &Open{},
-	"add":        &Add{},
-	"message":    &Message{},
-	"list":       &List{},
-	"nameplates": &Nameplates{},
-	"release":    &Release{},
-	"released":   &ReleasedResp{},
-	"error":      &Error{},
-	"close":      &Close{},
-	"closed":     &ClosedResp{},
+var msgMap = map[string]RendezvousType{
+	"welcome":    NewWelcome(),
+	"bind":       NewBind("", "", nil),
+	"allocate":   NewAllocate(),
+	"ack":        NewAck(),
+	"allocated":  NewAllocatedResp(),
+	"claim":      NewClaim(""),
+	"claimed":    NewClaimedResp(),
+	"open":       NewOpen(""),
+	"add":        NewAdd("", ""),
+	"message":    NewMessage(),
+	"list":       NewList(),
+	"nameplates": NewNameplates(),
+	"release":    NewRelease(""),
+	"released":   NewReleasedResp(),
+	"error":      NewError("", nil),
+	"close":      NewClose("", ""),
+	"closed":     NewClaimedResp(),
 }
 
 func TestStructTags(t *testing.T) {
 	for n, iface := range msgMap {
-		value := iface.RendezvousValue()
+		value := iface.GetType()
 		if value != n {
 			t.Errorf("msgMap key / Type struct tag rendezvous_value mismatch: key=%s tag=%s struct=%T", n, value, iface)
 		}

--- a/rendezvous/internal/msgs/msgs_test.go
+++ b/rendezvous/internal/msgs/msgs_test.go
@@ -21,14 +21,14 @@ var msgMap = map[string]RendezvousType{
 	"released":   NewReleasedResp(),
 	"error":      NewError("", nil),
 	"close":      NewClose("", ""),
-	"closed":     NewClaimedResp(),
+	"closed":     NewClosedResp(),
 }
 
 func TestStructTags(t *testing.T) {
 	for n, iface := range msgMap {
 		value := iface.GetType()
 		if value != n {
-			t.Errorf("msgMap key / Type struct tag rendezvous_value mismatch: key=%s tag=%s struct=%T", n, value, iface)
+			t.Fatalf("msgMap key / Type struct tag rendezvous_value mismatch: key=%s tag=%s struct=%T", n, value, iface)
 		}
 	}
 }

--- a/rendezvous/internal/msgs/msgs_test.go
+++ b/rendezvous/internal/msgs/msgs_test.go
@@ -1,21 +1,34 @@
 package msgs
 
 import (
-	"reflect"
 	"testing"
 )
 
+var msgMap = map[string]RendezvousValue{
+	"welcome":    &Welcome{},
+	"bind":       &Bind{},
+	"allocate":   &Allocate{},
+	"ack":        &Ack{},
+	"allocated":  &AllocatedResp{},
+	"claim":      &Claim{},
+	"claimed":    &ClaimedResp{},
+	"open":       &Open{},
+	"add":        &Add{},
+	"message":    &Message{},
+	"list":       &List{},
+	"nameplates": &Nameplates{},
+	"release":    &Release{},
+	"released":   &ReleasedResp{},
+	"error":      &Error{},
+	"close":      &Close{},
+	"closed":     &ClosedResp{},
+}
+
 func TestStructTags(t *testing.T) {
-	for n, iface := range MsgMap {
-		st := reflect.TypeOf(iface)
-		for i := 0; i < st.NumField(); i++ {
-			field := st.Field(i)
-			if field.Name == "Type" {
-				tagVal, _ := field.Tag.Lookup("rendezvous_value")
-				if tagVal != n {
-					t.Errorf("msgMap key / Type struct tag rendezvous_value mismatch: key=%s tag=%s struct=%T", n, tagVal, iface)
-				}
-			}
+	for n, iface := range msgMap {
+		value := iface.RendezvousValue()
+		if value != n {
+			t.Errorf("msgMap key / Type struct tag rendezvous_value mismatch: key=%s tag=%s struct=%T", n, value, iface)
 		}
 	}
 }

--- a/rendezvous/internal/msgs/msgs_test.go
+++ b/rendezvous/internal/msgs/msgs_test.go
@@ -6,7 +6,7 @@ import (
 
 var msgMap = map[string]RendezvousType{
 	"welcome":    NewWelcome(),
-	"bind":       NewBind("", "", nil),
+	"bind":       NewBind("", "", [2]string{}),
 	"allocate":   NewAllocate(),
 	"ack":        NewAck(),
 	"allocated":  NewAllocatedResp(),

--- a/rendezvous/internal/msgs/types.go
+++ b/rendezvous/internal/msgs/types.go
@@ -1,0 +1,14 @@
+package msgs
+
+type RendezvousType interface {
+	GetType() string
+}
+
+type RendezvousID interface {
+	GetID() string
+}
+
+type TypeAndID interface {
+	RendezvousType
+	RendezvousID
+}

--- a/rendezvous/internal/msgs/value.go
+++ b/rendezvous/internal/msgs/value.go
@@ -1,0 +1,5 @@
+package msgs
+
+type RendezvousValue interface {
+	RendezvousValue() string
+}

--- a/rendezvous/internal/msgs/value.go
+++ b/rendezvous/internal/msgs/value.go
@@ -1,5 +1,0 @@
-package msgs
-
-type RendezvousValue interface {
-	RendezvousValue() string
-}

--- a/rendezvous/rendezvousservertest/rendezvousservertest.go
+++ b/rendezvous/rendezvousservertest/rendezvousservertest.go
@@ -261,7 +261,7 @@ func (ts *TestServer) handleWS(w http.ResponseWriter, r *http.Request) {
 			}
 
 			ts.mu.Lock()
-			ts.agents = append(ts.agents, m.ClientVersion)
+			ts.agents = append(ts.agents, m.ClientVersion[:])
 			ts.mu.Unlock()
 			sideID = m.Side
 

--- a/rendezvous/rendezvousservertest/rendezvousservertest.go
+++ b/rendezvous/rendezvousservertest/rendezvousservertest.go
@@ -217,11 +217,7 @@ func (ts *TestServer) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	errMsg := func(id string, orig interface{}, reason error) {
-		errPacket := &msgs.Error{
-			Error: reason.Error(),
-			Orig:  orig,
-		}
-
+		errPacket := msgs.NewError(reason.Error(), orig)
 		sendMsg(errPacket)
 	}
 

--- a/rendezvous/rendezvousservertest/rendezvousservertest.go
+++ b/rendezvous/rendezvousservertest/rendezvousservertest.go
@@ -139,6 +139,26 @@ func prepareServerMsg(msg interface{}) {
 	}
 }
 
+var msgMap = map[string]interface{}{
+	"welcome":    msgs.Welcome{},
+	"bind":       msgs.Bind{},
+	"allocate":   msgs.Allocate{},
+	"ack":        msgs.Ack{},
+	"allocated":  msgs.AllocatedResp{},
+	"claim":      msgs.Claim{},
+	"claimed":    msgs.ClaimedResp{},
+	"open":       msgs.Open{},
+	"add":        msgs.Add{},
+	"message":    msgs.Message{},
+	"list":       msgs.List{},
+	"nameplates": msgs.Nameplates{},
+	"release":    msgs.Release{},
+	"released":   msgs.ReleasedResp{},
+	"error":      msgs.Error{},
+	"close":      msgs.Close{},
+	"closed":     msgs.ClosedResp{},
+}
+
 func serverUnmarshal(m []byte) (interface{}, error) {
 	var genericMsg msgs.GenericServerMsg
 	err := json.Unmarshal(m, &genericMsg)
@@ -146,7 +166,7 @@ func serverUnmarshal(m []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	protoType, found := msgs.MsgMap[genericMsg.Type]
+	protoType, found := msgMap[genericMsg.Type]
 	if !found {
 		return nil, fmt.Errorf("unknown msg type: %s %v %s", genericMsg.Type, genericMsg, m)
 	}


### PR DESCRIPTION
This moves the `rendezvous_value:` tag to instead be an interface with a getter method. The tag is used in other parts of the code for now but should be possible to remove after more work has landed.

The `MsgMap` from the internal package was split into two. One in the test, for testing the specific values, and one in the `rendezvousservertest` for testing the json marshalling (the latter using interface{} instead of the new type). This avoids compiling in the map into binaries given that it was never used outside of testing.

For #83  