### PR TITLE
Set stricter directory permissions

### DIFF
--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -173,7 +173,7 @@ func recvAction(cmd *cobra.Command, args []string) {
 				msg.Reject()
 				bail("transfer rejected")
 			} else {
-				err = os.Mkdir(msg.Name, 0755)
+				err = os.Mkdir(msg.Name, 0700)
 				if err != nil {
 					bail("Mkdir error for %s: %s\n", msg.Name, err)
 				}
@@ -215,7 +215,7 @@ func recvAction(cmd *cobra.Command, args []string) {
 					}
 
 					dir := filepath.Dir(p)
-					err = os.MkdirAll(dir, 0755)
+					err = os.MkdirAll(dir, 0700)
 					if err != nil {
 						bail("Failed to mkdirall %s: %s", dir, err)
 					}

--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -173,7 +173,7 @@ func recvAction(cmd *cobra.Command, args []string) {
 				msg.Reject()
 				bail("transfer rejected")
 			} else {
-				err = os.Mkdir(msg.Name, 0777)
+				err = os.Mkdir(msg.Name, 0755)
 				if err != nil {
 					bail("Mkdir error for %s: %s\n", msg.Name, err)
 				}
@@ -215,7 +215,7 @@ func recvAction(cmd *cobra.Command, args []string) {
 					}
 
 					dir := filepath.Dir(p)
-					err = os.MkdirAll(dir, 0777)
+					err = os.MkdirAll(dir, 0755)
 					if err != nil {
 						bail("Failed to mkdirall %s: %s", dir, err)
 					}
@@ -223,6 +223,11 @@ func recvAction(cmd *cobra.Command, args []string) {
 					f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, zf.Mode())
 					if err != nil {
 						bail("Failed to open %s: %s", p, err)
+					}
+					mode := zf.Mode()
+					err = os.Chmod(p, mode)
+					if err != nil {
+						bail("error setting mode for %s: %s", p, err)
 					}
 
 					_, err = io.Copy(f, rc)


### PR DESCRIPTION
Directory transfer of the transit protocol use the zip format internally to transfer a bunch of files/directories from the sender to the recipient. The recipient, creates the destination directory and unzips the zip file to recreate the directory that was sent by the sender. This process is transparent to the user.

This PR address two issues:

1. wormhole-william is using `0777` for directory permissions at the creation time. This seems excessive. I believe, this was discussed in the past, but I can't find the right issue at the moment. We set it to a stricter `0700`.
2. For a wormhole-william to wormhole-william transfer on Un*x based systems (macOS, GNU/Linux), the file permissions on the sender side are restored at the recipient side as well. Sender is [already](https://github.com/psanford/wormhole-william/blob/master/wormhole/send.go#L561) sending the permission bits in the [attributes field](https://github.com/klauspost/compress/blob/5a16edccd2a4c68d0d3a6844728cee0f41432c40/zip/struct.go#L137) of the zip file entry. These bits are restored upon receive.