### PR TITLE
Update to latest Go 1.21.x for release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20.x"
+          go-version: "1.21.x"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20.1"
+          go-version: "1.20.x"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.19.4"
+          go-version: "1.20.1"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build Artifacts


### PR DESCRIPTION
This updates the release workflow to build using the latest version of Go 1.20.x.