### PR TITLE
wormhole: Collect messages without using reflect package

### DIFF
--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -98,7 +98,7 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 	defer collector.close()
 
 	var offer offerMsg
-	err = collector.waitFor(&offer)
+	err = collector.waitForOffer(&offer)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (c *Client) Receive(ctx context.Context, code string) (fr *IncomingMessage,
 	}
 
 	var gotTransitMsg transitMsg
-	err = collector.waitFor(&gotTransitMsg)
+	err = collector.waitForTransit(&gotTransitMsg)
 	if err != nil {
 		return nil, err
 	}

--- a/wormhole/send.go
+++ b/wormhole/send.go
@@ -154,7 +154,7 @@ func (c *Client) SendText(ctx context.Context, msg string, opts ...SendOption) (
 		defer collector.close()
 
 		var answer answerMsg
-		err = collector.waitFor(&answer)
+		err = collector.waitForAnswer(&answer)
 		if err != nil {
 			sendErr(err)
 			return
@@ -341,7 +341,7 @@ func (c *Client) sendFileDirectory(ctx context.Context, offer *offerMsg, r io.Re
 		defer collector.close()
 
 		var answer answerMsg
-		err = collector.waitFor(&answer)
+		err = collector.waitForAnswer(&answer)
 		if err != nil {
 			sendErr(err)
 			return


### PR DESCRIPTION
This implements the message collection in the `waitFor` method without using the `reflect` package. We can use a type switch and copy over the field values directly and also make sure that non-pointer values or unsupported collector types return an error.

This implementation uses a bit less "magic" and is more understandable in my opinion.

Supersedes #94