### PR TITLE
Remove channel intercept for closing files

### DIFF
--- a/wormhole/wormhole_test.go
+++ b/wormhole/wormhole_test.go
@@ -329,7 +329,7 @@ func TestWormholeBigFileTransportSendRecvViaRelayServer(t *testing.T) {
 	r := bytes.NewReader(make([]byte, 1))
 
 	// skip th wrapper so we can provide our own offer
-	code, _, err := c0.sendFileDirectory(ctx, offer, r)
+	code, _, err := c0.sendFileDirectory(ctx, offer, ioutil.NopCloser(r))
 	//c0.SendFile(ctx, "file.txt", buf)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The code can be simplified to take in an io.ReadCloser and then close the file where necessary instead. Doing it this way avoids having to spin up a goroutine and intercept the channel to then send the information through another channel.