### PR TITLE
Build for netbsd-amd64

### DIFF
--- a/build_release.go
+++ b/build_release.go
@@ -98,4 +98,5 @@ var targets = []target{
 	{"windows", "arm64", ""},
 	{"windows", "386", ""},
 	{"freebsd", "amd64", ""},
+	{"netbsd", "amd64", ""},
 }


### PR DESCRIPTION
wormhole-william cross-compiles for and works on NetBSD. I would like to put it on my [list](http://dbohdan.sdf.org/#netbsd-official-bin) of software with official NetBSD binaries. :-)