### PR TITLE
Add interactive recv code completion

### DIFF
--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -15,6 +15,7 @@ import (
 	"github.com/klauspost/compress/zip"
 	"github.com/psanford/wormhole-william/wormhole"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 func recvCommand() *cobra.Command {
@@ -28,7 +29,7 @@ func recvCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&verify, "verify", "v", false, "display verification string (and wait for approval)")
 	cmd.Flags().BoolVar(&hideProgressBar, "hide-progress", false, "suppress progress-bar display")
 
-	cmd.ValidArgsFunction = recvCodeCompletion
+	cmd.ValidArgsFunction = recvCodeCompletionCobra
 
 	return &cmd
 }
@@ -45,14 +46,11 @@ func recvAction(cmd *cobra.Command, args []string) {
 	}
 
 	if code == "" {
-		reader := bufio.NewReader(os.Stdin)
-		fmt.Print("Enter receive wormhole code: ")
-
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			errf("Error reading from stdin: %s\n", err)
-		}
-		code = strings.TrimSpace(line)
+		code = readCode()
+	}
+	if code == "" {
+		// Consider the action canceled.
+		os.Exit(0)
 	}
 
 	if verify {
@@ -249,6 +247,42 @@ func errf(msg string, args ...interface{}) {
 	if !strings.HasSuffix("\n", msg) {
 		fmt.Fprint(os.Stderr, "\n")
 	}
+}
+
+func readCode() string {
+	prompt := "Enter receive wormhole code: "
+	line := ""
+
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+		if err != nil {
+			errf("Error setting terminal to raw mode: %s\n", err)
+		}
+
+		t := term.NewTerminal(os.Stdin, prompt)
+		t.SetBracketedPasteMode(true)
+		t.AutoCompleteCallback = autoCompleteCode
+
+		line, err = t.ReadLine()
+		term.Restore(int(os.Stdin.Fd()), oldState)
+		if err != nil {
+			fmt.Println()
+			if err.Error() != "EOF" {
+				errf("Error reading from terminal: %s", err)
+			}
+		}
+	} else {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print(prompt)
+
+		var err error
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			errf("Error reading from stdin: %s\n", err)
+		}
+	}
+
+	return strings.TrimSpace(line)
 }
 
 func bail(msg string, args ...interface{}) {

--- a/cmd/recv.go
+++ b/cmd/recv.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/cheggaaa/pb/v3"
@@ -253,7 +254,7 @@ func readCode() string {
 	prompt := "Enter receive wormhole code: "
 	line := ""
 
-	if term.IsTerminal(int(os.Stdin.Fd())) {
+	if runtime.GOOS != "windows" && term.IsTerminal(int(os.Stdin.Fd())) {
 		oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 		if err != nil {
 			errf("Error setting terminal to raw mode: %s\n", err)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mdp/qrterminal/v3 v3.2.0
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/crypto v0.31.0
+	golang.org/x/term v0.27.0
 	nhooyr.io/websocket v1.8.17
 	salsa.debian.org/vasudev/gospake2 v0.0.0-20210510093858-d91629950ad1
 )
@@ -23,6 +24,5 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.28.0 // indirect
-	golang.org/x/term v0.27.0 // indirect
 	rsc.io/qr v0.2.0 // indirect
 )


### PR DESCRIPTION
This implementation avoids adding a new readline library by using `golang.org/x/term`, which is already an indirect dependency. It is basic (doesn't display a list; keys like Home, End, and even Delete don't work) but nevertheless useful and closes the gap with the Python original.

Completion builds on the existing function `recvCodeCompletion`, which has been refactored to remove a return value and unused arguments specific to Cobra. It works on the last code word of the input line in one of three modes:

- If the current word is a complete code word from the word list and the cursor is at the end of the line, we replace the word with the next word on the list.
- If the current word is not a complete code word from the word list and the cursor is at the end of the line, we complete the word with the first completion from the list.
- If the cursor is in the middle of the word, we replace everything after the cursor with the next possible completion.

There is a fallback for systems where an interactive terminal isn't detected. Empty and whitespace input cancels the receive action without an error. This is because pressing Ctrl-C in `ReadLine` results in empty input. It seems like good UX anyway.

Resolves #105.